### PR TITLE
One idea: replace multiple newlines from templates

### DIFF
--- a/Mustache Prompt/MustachePrompt.js
+++ b/Mustache Prompt/MustachePrompt.js
@@ -86,7 +86,7 @@ function mustachePrompt(text, dateFormat) {
     //alert(JSON.stringify(data, 2))
     
     let template = MustacheTemplate.createWithTemplate(text)
-    let result = template.render(data)
+    let result = template.render(data).replace(/\n{2,}/g, "\n\n")
     return result
     
   } else {


### PR DESCRIPTION
Some of my templates ended up having chunks of several newlines (particularly when a boolean wasn't present). This pull request turns any 2+ newlines into only 2 newlines.